### PR TITLE
[Breaking Change] Add Task#logger and Task#log method 

### DIFF
--- a/examples/concurrent_task_run.rb
+++ b/examples/concurrent_task_run.rb
@@ -6,10 +6,9 @@ class FileTask < Tumugi::Task
   end
 
   def run
-    @logger.info "#{self.id}#run"
+    log 'sleep 5 seconds'
     sleep 5
     File.write(output.path, 'done')
-    @logger.info "#{self.id}#done"
   end
 end
 

--- a/lib/tumugi/task.rb
+++ b/lib/tumugi/task.rb
@@ -7,7 +7,6 @@ module Tumugi
     attr_accessor :state # :pending, :running, :completed, :skipped
 
     def initialize
-      @logger = Tumugi.logger
       @state = :pending
     end
 
@@ -29,6 +28,14 @@ module Tumugi
 
     def instance
       self
+    end
+
+    def logger
+      @logger ||= Tumugi.logger
+    end
+
+    def log(msg)
+      logger.info(msg)
     end
 
     # If you need to define task dependencies, override in subclass


### PR DESCRIPTION
and make @logger invisible from subclass.
Use `Task#logger` or `Task#log` method instead of @logger.
## v0.1.0

``` rb
class SubTask < Tumugi::Task
  def run
    @logger.info 'message'    
  end
end
```
## v0.2.0+

``` rb
class SubTask < Tumugi::Task
  def run
    logger.info 'message'    
  end
end
```

or

``` rb
class SubTask < Tumugi::Task
  def run
    log 'message' # Tumugi::Task.log is shortcut method of logger.info
  end
end
```
