### PR TITLE
[Breaking Change] Change eval scope of output, run method

### DIFF
--- a/examples/data_pipeline.rb
+++ b/examples/data_pipeline.rb
@@ -2,11 +2,11 @@ require 'tumugi/target/file_target'
 
 task :generate_data do
   output do
-    Tumugi::Target::FileTarget.new("/tmp/data_#{Time.now.strftime('%Y-%m-%d')}.txt")
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_data_#{Time.now.strftime('%Y-%m-%d')}.txt")
   end
 
-  run do |task|
-    File.open(task.output.path, "w") do |f|
+  run do
+    File.open(output.path, "w") do |f|
       (1..10).each do |i|
         f.puts i
       end
@@ -18,14 +18,14 @@ task :sum do
   requires :generate_data
 
   output do
-    Tumugi::Target::FileTarget.new("/tmp/output_#{Time.now.strftime('%Y-%m-%d')}.txt")
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_output_#{Time.now.strftime('%Y-%m-%d')}.txt")
   end
 
-  run do |task|
+  run do
     sum = 0
-    File.foreach(task.input.path) do |line|
+    File.foreach(input.path) do |line|
       sum += line.to_i
     end
-    File.write(task.output.path, sum)
+    File.write(output.path, sum)
   end
 end

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -1,21 +1,21 @@
 task :task1 do
   requires [:task2, :task3]
-  run { puts 'task1#run' }
+  run { log 'task1#run' }
 end
 
 task :task2 do
   requires [:task4]
-  run { puts 'task2#run' }
+  run { log 'task2#run' }
 end
 
 task :task3 do
   requires [:task4]
-  run { puts 'task3#run' }
+  run { log 'task3#run' }
 end
 
 task :task4 do
   run do
-    puts 'task4#run'
+    log 'task4#run'
     sleep 1
   end
 end

--- a/examples/target.rb
+++ b/examples/target.rb
@@ -3,49 +3,49 @@ require 'tumugi/target/file_target'
 task :task1 do
   requires [:task2, :task3]
 
-  output do |task|
-    Tumugi::Target::FileTarget.new("/tmp/#{task.id}.txt")
+  output do
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_#{id}.txt")
   end
 
-  run do |task|
-    puts 'task1#run'
-    File.write(task.output.path, 'done')
+  run do
+    log 'task1#run'
+    File.write(output.path, 'done')
   end
 end
 
 task :task2 do
   requires [:task4]
 
-  output do |task|
-    Tumugi::Target::FileTarget.new("/tmp/#{task.id}.txt")
+  output do
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_#{id}.txt")
   end
 
-  run do |task|
-    puts 'task2#run'
-    File.write(task.output.path, 'done')
+  run do
+    log 'task2#run'
+    File.write(output.path, 'done')
   end
 end
 
 task :task3 do
   requires [:task4]
 
-  output do |task|
-    Tumugi::Target::FileTarget.new("/tmp/#{task.id}.txt")
+  output do
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_#{id}.txt")
   end
 
-  run do |task|
-    puts 'task3#run'
-    File.write(task.output.path, 'done')
+  run do
+    log 'task3#run'
+    File.write(output.path, 'done')
   end
 end
 
 task :task4 do
   output do
-    Tumugi::Target::FileTarget.new('/tmp/task4.txt')
+    Tumugi::Target::FileTarget.new("/tmp/tumugi_#{id}.txt")
   end
 
-  run do |task|
-    puts 'task4#run'
-    File.write(task.output.path, 'done')
+  run do
+    log 'task4#run'
+    File.write(output.path, 'done')
   end
 end

--- a/examples/task_inheritance.rb
+++ b/examples/task_inheritance.rb
@@ -2,11 +2,11 @@ require 'tumugi/target/file_target'
 
 class FileTask < Tumugi::Task
   def output
-    Tumugi::Target::FileTarget.new("/tmp/#{self.id}.txt")
+    Tumugi::Target::FileTarget.new("/tmp/#{id}.txt")
   end
 
   def run
-    puts "#{self.id}#run"
+    log "#{id}#run"
     File.write(output.path, 'done')
   end
 end

--- a/lib/tumugi/task.rb
+++ b/lib/tumugi/task.rb
@@ -63,7 +63,11 @@ module Tumugi
 
     def completed?
       outputs = list(output)
-      !outputs.empty? && outputs.all?(&:exist?)
+      if outputs.empty?
+        @state == :completed || @state == :skipped
+      else
+        outputs.all?(&:exist?)
+      end
     end
 
     # Following methods are internal use only

--- a/lib/tumugi/task_definition.rb
+++ b/lib/tumugi/task_definition.rb
@@ -6,7 +6,7 @@ module Tumugi
 
     def self.define(id, opts={}, &block)
       td = Tumugi::TaskDefinition.new(id, opts)
-      td.instance_eval(&block)
+      td.instance_eval(&block) if block_given?
       Tumugi.application.add_task(id, td)
       td
     end
@@ -35,7 +35,7 @@ module Tumugi
     end
 
     def output_eval(task)
-      @out ||= @outputs.is_a?(Proc) ? @outputs.call(task) : @outputs
+      @out ||= @outputs.is_a?(Proc) ? task.instance_eval(&@outputs) : @outputs
     end
 
     def required_tasks
@@ -43,7 +43,7 @@ module Tumugi
     end
 
     def run_block(task)
-      @run.call(task)
+      task.instance_eval(&@run)
     end
 
     private


### PR DESCRIPTION
This PR change eval scope of output and run method, from eval global namespace to instance_eval of task. This change make us to write code more short and better consistency between DSL and Class style code.
## Before

``` rb
task :task1 do
  output do |task|
    Tumugi::Target::FileTarget.new("#{task.id}.txt")
  end

  run do |task|
    File.write(task.output.path, "done")
  end
end
```
## After

``` rb
task :task1 do
  output do
    Tumugi::Target::FileTarget.new("#{id}.txt")
  end

  run do
    File.write(output.path, "done")
  end
end
```
