### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/tumugi.gemspec
+++ b/tumugi.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0'
+
   spec.add_runtime_dependency 'parallel', '~> 1.8.0'
   spec.add_runtime_dependency 'retriable', '~> 2.1'
   spec.add_runtime_dependency 'ruby-graphviz', '~> 1.2.2'


### PR DESCRIPTION
to restrict install only Ruby >= 2.0
