### PR TITLE
Implement workflow run result report

### DIFF
--- a/tumugi.gemspec
+++ b/tumugi.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'parallel', '~> 1.8.0'
   spec.add_runtime_dependency 'retriable', '~> 2.1'
   spec.add_runtime_dependency 'ruby-graphviz', '~> 1.2.2'
+  spec.add_runtime_dependency 'terminal-table', '~> 1.5.2'
   spec.add_runtime_dependency 'thor', '~> 0.19.1'
 
   spec.add_development_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
For #23 

``` sh
$ bundle exec tumugi run -f ./examples/task_parameter.rb task1 -p key1:value1
I, [2016-05-06T18:30:41.710164 #43887]  INFO -- : start: task3
I, [2016-05-06T18:30:41.710262 #43887]  INFO -- : run: task3
I, [2016-05-06T18:30:41.710358 #43887]  INFO -- : key3=default value
I, [2016-05-06T18:30:41.710390 #43887]  INFO -- : completed: task3
I, [2016-05-06T18:30:41.710420 #43887]  INFO -- : start: task2
I, [2016-05-06T18:30:41.710450 #43887]  INFO -- : run: task2
I, [2016-05-06T18:30:41.710498 #43887]  INFO -- : key1=
I, [2016-05-06T18:30:41.710522 #43887]  INFO -- : key2=value2
I, [2016-05-06T18:30:41.710547 #43887]  INFO -- : completed: task2
I, [2016-05-06T18:30:41.710575 #43887]  INFO -- : start: task1
I, [2016-05-06T18:30:41.710623 #43887]  INFO -- : run: task1
I, [2016-05-06T18:30:41.710670 #43887]  INFO -- : key1=value1
I, [2016-05-06T18:30:41.710695 #43887]  INFO -- : key2=
I, [2016-05-06T18:30:41.710718 #43887]  INFO -- : completed: task1
I, [2016-05-06T18:30:41.713097 #43887]  INFO -- : Result report:
+-------+----------+--------------------+-----------+
| Task  | Requires | Parameters         | State     |
+-------+----------+--------------------+-----------+
| task1 | task2    | key1=value1        | completed |
|       |          | key2=              |           |
| task2 | task3    | key1=              | completed |
|       |          | key2=value2        |           |
| task3 |          | key3=default value | completed |
+-------+----------+--------------------+-----------+
```
