### PR TITLE
Fix workflow dead locked when some task failed

### DIFF
--- a/examples/fail_first_task.rb
+++ b/examples/fail_first_task.rb
@@ -1,0 +1,20 @@
+task :task1 do
+  requires [:task2, :task3]
+  run { log 'task1#run' }
+end
+
+task :task2 do
+  requires [:task4]
+  run { log 'task2#run' }
+end
+
+task :task3 do
+  requires [:task4]
+  run { log 'task3#run' }
+end
+
+task :task4 do
+  run do
+    raise "error in #{id}"
+  end
+end

--- a/examples/fail_intermediate_task.rb
+++ b/examples/fail_intermediate_task.rb
@@ -1,0 +1,21 @@
+task :task1 do
+  requires [:task2, :task3]
+  run { log 'task1#run' }
+end
+
+task :task2 do
+  requires [:task4]
+  run { raise "error in #{id}" }
+end
+
+task :task3 do
+  requires [:task4]
+  run { log 'task3#run' }
+end
+
+task :task4 do
+  run do
+    log 'task4#run'
+    sleep 1
+  end
+end

--- a/examples/fail_last_task.rb
+++ b/examples/fail_last_task.rb
@@ -1,0 +1,21 @@
+task :task1 do
+  requires [:task2, :task3]
+  run { raise "error in #{id}" }
+end
+
+task :task2 do
+  requires [:task4]
+  run { log 'task2#run' }
+end
+
+task :task3 do
+  requires [:task4]
+  run { log 'task3#run' }
+end
+
+task :task4 do
+  run do
+    log 'task4#run'
+    sleep 1
+  end
+end

--- a/examples/tumugi_config.rb
+++ b/examples/tumugi_config.rb
@@ -1,0 +1,4 @@
+Tumugi.config do |c|
+  c.max_retry = 3
+  c.retry_interval = 1
+end

--- a/lib/tumugi/cli.rb
+++ b/lib/tumugi/cli.rb
@@ -11,6 +11,10 @@ module Tumugi
         option :config, aliases: '-c', desc: 'Configuration file name', default: 'tumugi.rb'
         option :params, aliases: '-p', type: :hash, desc: 'Task parameters'
       end
+
+      def exit_on_failure?
+        true
+      end
     end
 
     desc "version", "Show version"

--- a/lib/tumugi/task.rb
+++ b/lib/tumugi/task.rb
@@ -75,6 +75,10 @@ module Tumugi
       end
     end
 
+    def requires_failed?
+      list(_requires).any? { |t| t.instance.state == :failed || t.instance.state == :requires_failed }
+    end
+
     # Following methods are internal use only
 
     def _requires

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -10,6 +10,12 @@ class Tumugi::CLITest < Test::Unit::TestCase
     'task_parameter' => ['task_parameter.rb', 'task1'],
   }
 
+  failed_examples = {
+    'fail_first_task' => ['fail_first_task.rb', 'task1'],
+    'fail_intermediate_task' => ['fail_intermediate_task.rb', 'task1'],
+    'fail_last_task' => ['fail_last_task.rb', 'task1'],
+  }
+
   def exec(command, file, task, options)
     system("bundle exec ./exe/tumugi #{command} -f ./examples/#{file} #{task} #{options}")
   end
@@ -18,9 +24,16 @@ class Tumugi::CLITest < Test::Unit::TestCase
     system('rm -rf /tmp/tumugi_*')
   end
 
-  data(examples)
-  test 'run' do |(file, task)|
-    assert_true(exec('run', file, task, "-w 4 --quiet -p key1:value1"))
+  sub_test_case 'run' do
+    data(examples)
+    test 'success' do |(file, task)|
+      assert_true(exec('run', file, task, "-w 4 --quiet -p key1:value1"))
+    end
+
+    data(failed_examples)
+    test 'fail' do |(file, task)|
+      assert_false(exec('run', file, task, "-w 4 --quiet -c ./examples/tumugi_config.rb"))
+    end
   end
 
   sub_test_case 'show' do

--- a/test/command/run_test.rb
+++ b/test/command/run_test.rb
@@ -39,7 +39,9 @@ class Tumugi::Command::RunTest < Test::Unit::TestCase
         c.retry_interval = 1
       end
 
-      @cmd.execute(@dag)
+      assert_raise(::Thor::Error) do
+        @cmd.execute(@dag)
+      end
       assert_equal(:failed, @task.state)
     end
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -170,4 +170,20 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       end
     end
   end
+
+  sub_test_case '#requires_failed' do
+    test 'return true when requires task is failed' do
+      requires_task = TestTask.new(output: NotExistOutput.new)
+      requires_task.state = :failed
+      task = TestTask.new(requires: requires_task)
+      assert_true(task.requires_failed?)
+    end
+
+    test 'return false when requires task is completed' do
+      requires_task = TestTask.new(output: NotExistOutput.new)
+      requires_task.state = :completed
+      task = TestTask.new(requires: requires_task)
+      assert_false(task.requires_failed?)
+    end
+  end
 end


### PR DESCRIPTION
For example, following DAG, if task2 failed, task1 wait forever. This PR fix the issue.

![Alt text](http://g.gravizo.com/g?
  digraph G {
    rankdir=LR;
    Task2 -> Task1
    Task3 -> Task1;
    Task4 -> Task2;
    Task4 -> Task3;
  })

This PR also fix return code of CLI is 0 even if task failed.
