### PR TITLE
Fix param_set in subclass overrite parent class param

### DIFF
--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -11,10 +11,11 @@ module Tumugi
       def initialize
         super()
         proxy = self.class.merged_parameter_proxy
-        params = proxy.params
+        params = proxy.params.dup
         proxy.param_defaults.each do |name, value|
-          param = params[name]
-          param.overwrite_default(value) if param
+          if params[name]
+            params[name] = params[name].merge_default_value(value)
+          end
         end
         params.each do |name, param|
           unless proxy.param_auto_bind_enabled.nil?

--- a/lib/tumugi/parameter/parameter.rb
+++ b/lib/tumugi/parameter/parameter.rb
@@ -48,9 +48,8 @@ module Tumugi
         @opts[:default] || nil
       end
 
-      def overwrite_default(value)
-        @opts[:required] = false
-        @opts[:default] = value
+      def merge_default_value(value)
+        self.class.new(@name, @opts.merge(required: false, default: value))
       end
 
       private

--- a/test/parameter/parameter_test.rb
+++ b/test/parameter/parameter_test.rb
@@ -108,18 +108,18 @@ class Tumugi::Parameter::ParameterTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case '#overwrite_default' do
-    test 'should overwrite default value' do
+  sub_test_case '#merge_default_value' do
+    test 'should merge default value' do
       param = Tumugi::Parameter::Parameter.new(:name, default: 'default')
-      param.overwrite_default('value1')
-      assert_equal('value1', param.get)
+      merged = param.merge_default_value('value1')
+      assert_equal('value1', merged.get)
     end
 
     test 'should disable required implicitly' do
       param = Tumugi::Parameter::Parameter.new(:name, required: true)
-      param.overwrite_default('value1')
-      assert_equal('value1', param.get)
-      assert_false(param.required?)
+      merged = param.merge_default_value('value1')
+      assert_equal('value1', merged.get)
+      assert_false(merged.required?)
     end
   end
 end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -35,7 +35,11 @@ class Tumugi::TaskTest < Test::Unit::TestCase
   end
 
   class TestSubSubTask < TestSubTask
-    param_set :param_string_in_subclass, 'test'
+    param_set :param_string_in_subclass, 'TestSubSubTask'
+  end
+
+  class TestSubSub2Task < TestSubTask
+   param_set :param_string_in_subclass, 'TestSubSub2Task'
   end
 
   setup do
@@ -178,7 +182,13 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       task = TestSubSubTask.new
       assert_true(task.respond_to? "param_string_in_subclass".to_sym)
       assert_true(task.respond_to? "param_string_in_subclass=".to_sym)
-      assert_equal('test', task.param_string_in_subclass)
+      assert_equal('TestSubSubTask', task.param_string_in_subclass)
+
+      # Check between subclasses are not affected each other
+      task = TestSubSub2Task.new
+      assert_true(task.respond_to? "param_string_in_subclass".to_sym)
+      assert_true(task.respond_to? "param_string_in_subclass=".to_sym)
+      assert_equal('TestSubSub2Task', task.param_string_in_subclass)
     end
   end
 


### PR DESCRIPTION
```
class TestSubTask < Tumugi::Task
  param :param_string_in_subclass, required: true
end

class TestSubSubTask < TestSubTask
  param_set :param_string_in_subclass, 'TestSubSubTask'
end
```

Then

```
TestSubSubTask.new

# This code should throw Tumugi::Parameter::ParameterError, but not.
# Because `param_string_in_subclass` is overwrited when `TestSubSubTask.new` called
TestSubTask.new 
```
