### PR TITLE
Param set accept proc

### DIFF
--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -57,7 +57,15 @@ module Tumugi
 
         def param(name, opts={})
           parameter_proxy(proxy_id).param(name, opts)
-          attr_accessor name
+          attr_writer name
+          define_method(name) do
+            val = self.instance_variable_get("@#{name}")
+            if val.instance_of?(Proc)
+              self.instance_exec(&val)
+            else
+              val
+            end
+          end
         end
 
         def param_set(name, value)

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -39,7 +39,16 @@ class Tumugi::TaskTest < Test::Unit::TestCase
   end
 
   class TestSubSub2Task < TestSubTask
-   param_set :param_string_in_subclass, 'TestSubSub2Task'
+    param_set :param_string_in_subclass, 'TestSubSub2Task'
+  end
+
+  class TestSubSub3Task < TestSubTask
+    param_set :param_string_in_subclass, ->{ @value }
+
+    def initialize(value)
+      super()
+      @value = value
+    end
   end
 
   setup do
@@ -189,6 +198,11 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       assert_true(task.respond_to? "param_string_in_subclass".to_sym)
       assert_true(task.respond_to? "param_string_in_subclass=".to_sym)
       assert_equal('TestSubSub2Task', task.param_string_in_subclass)
+    end
+
+    test 'param_set can accept Proc and evaluate it later and instance scope' do
+      task = TestSubSub3Task.new('test')
+      assert_equal('test', task.param_string_in_subclass)
     end
   end
 


### PR DESCRIPTION
This PR make `param_set` to accept  `Proc` object.
So that we can use set parameter value from instance variable.

``` rb
task :task1 do
  param_set :param, Proc.new { id }
end
```
