### PR TITLE
Fix workflow result output of parameters

### DIFF
--- a/lib/tumugi/command/run.rb
+++ b/lib/tumugi/command/run.rb
@@ -83,7 +83,7 @@ module Tumugi
               r.id
             end
             params = proxy.params.map do |name, _|
-              "#{name}=#{task.instance_variable_get("@#{name}")}"
+              "#{name}=#{task.send(name.to_sym)}"
             end
             t << [ task.id, requires.join("\n"), params.join("\n"), task.state ]
           end

--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -61,7 +61,9 @@ module Tumugi
           define_method(name) do
             val = self.instance_variable_get("@#{name}")
             if val.instance_of?(Proc)
-              self.instance_exec(&val)
+              v = self.instance_exec(&val)
+              self.instance_variable_set("@#{name}", v)
+              v
             else
               val
             end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -43,7 +43,7 @@ class Tumugi::TaskTest < Test::Unit::TestCase
   end
 
   class TestSubSub3Task < TestSubTask
-    param_set :param_string_in_subclass, ->{ @value }
+    param_set :param_string_in_subclass, ->{ @value += 1 }
 
     def initialize(value)
       super()
@@ -200,9 +200,10 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       assert_equal('TestSubSub2Task', task.param_string_in_subclass)
     end
 
-    test 'param_set can accept Proc and evaluate it later and instance scope' do
-      task = TestSubSub3Task.new('test')
-      assert_equal('test', task.param_string_in_subclass)
+    test 'param_set can accept Proc and evaluate it later and instance scope and cache results' do
+      task = TestSubSub3Task.new(1)
+      assert_equal(2, task.param_string_in_subclass)
+      assert_equal(2, task.param_string_in_subclass)
     end
   end
 


### PR DESCRIPTION
This PR fixed 2 issues.

When parameter is `Proc`
- Task parameter might be different value each property access
- Workflow result output of parameters is bad like following

``` sh
+-------+----------+----------------------------------------------------------------------------+-----------+
| Task  | Requires | Parameters                                                                 | State     |
+-------+----------+----------------------------------------------------------------------------+-----------+
| task1 | task2    | src_project=#<Proc:0x007fc174b34df8@examples/copy.rb:2 (lambda)>           | skipped   |
|       |          | src_dataset=#<Proc:0x007fc174b34d80@examples/copy.rb:3 (lambda)>           |           |
|       |          | src_table=#<Proc:0x007fc174b34ce0@examples/copy.rb:4 (lambda)>             |           |
|       |          | dest_project=                                                              |           |
|       |          | dest_dataset=test                                                          |           |
|       |          | dest_table=dest_table                                                      |           |
|       |          | wait=60                                                                    |           |
| task2 | task3    | query=SELECT COUNT(*) AS cnt FROM [bigquery-public-data:samples.wikipedia] | completed |
|       |          | project=                                                                   |           |
|       |          | dataset=test                                                               |           |
|       |          | table=dest_1463139483                                                      |           |
|       |          | wait=                                                                      |           |
| task3 |          | project=                                                                   | skipped   |
|       |          | dataset=test                                                               |           |
+-------+----------+----------------------------------------------------------------------------+-----------+
```
