### PR TITLE
Fix required parameter validation

### DIFF
--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -23,7 +23,7 @@ module Tumugi
           end
           instance_variable_set("@#{name}", param.get)
         end
-        validate_params(params)
+        validate_params(proxy.params)
         configure
       end
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -181,9 +181,19 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       assert_equal(deafult_value, task.send(name.to_sym))
     end
 
-    test 'raise ParameterError when required parameter is not set' do
-      assert_raise(Tumugi::Parameter::ParameterError) do
-        TestSubTask.new
+    sub_test_case 'raise ParameterError when required parameter is not set' do
+      test 'not set' do
+        assert_raise(Tumugi::Parameter::ParameterError) do
+          TestSubTask.new
+        end
+      end
+
+      test 'set nil' do
+        klass = Class.new(TestSubTask)
+        klass.param_set(:param_string_in_subclass, nil)
+        assert_raise(Tumugi::Parameter::ParameterError) do
+          klass.new
+        end
       end
     end
 


### PR DESCRIPTION
This bug is introduced v0.4.4.
When we create workflow like following, required check is not working.

``` rb
class ParamTask < Tumugi::Task
  param :param1, required: true
end

class SubTask < ParamTask
  param_set :param1, nil
end
```
