### PR TITLE
Restruct error handling

### DIFF
--- a/lib/tumugi/application.rb
+++ b/lib/tumugi/application.rb
@@ -44,7 +44,7 @@ module Tumugi
       begin
         load(file, true)
       rescue LoadError => e
-        raise Tumugi::TumugiError, e.message
+        raise Tumugi::TumugiError.new("Workflow file load error: #{file}", e)
       end
     end
 
@@ -77,7 +77,7 @@ module Tumugi
         load(config_file)
       end
     rescue LoadError => e
-      raise Tumugi::TumugiError, e.message
+      raise Tumugi::TumugiError.new("Config file load error: #{config_file}", e)
     end
 
     def set_params(options)

--- a/lib/tumugi/command/run.rb
+++ b/lib/tumugi/command/run.rb
@@ -39,6 +39,7 @@ module Tumugi
               t.state = :failed
               logger.info "#{t.state}: #{t.id}"
               logger.error "#{e.message}"
+              logger.error e.backtrace.join("\n")
             else
               t.state = :completed
               logger.info "#{t.state}: #{t.id}"

--- a/lib/tumugi/config.rb
+++ b/lib/tumugi/config.rb
@@ -1,7 +1,6 @@
-module Tumugi
-  class ConfigError < StandardError
-  end
+require 'tumugi/error'
 
+module Tumugi
   class Config
     attr_accessor :workers, :max_retry, :retry_interval, :param_auto_bind_enabled
 

--- a/lib/tumugi/error.rb
+++ b/lib/tumugi/error.rb
@@ -1,4 +1,10 @@
 module Tumugi
   class TumugiError < StandardError
   end
+
+  class ConfigError < TumugiError
+  end
+
+  class ParameterError < TumugiError
+  end
 end

--- a/lib/tumugi/error.rb
+++ b/lib/tumugi/error.rb
@@ -1,5 +1,11 @@
 module Tumugi
   class TumugiError < StandardError
+    attr_reader :reason
+
+    def initialize(message=nil, reason=nil)
+      super(message)
+      @reason = reason
+    end
   end
 
   class ConfigError < TumugiError

--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -1,4 +1,4 @@
-require 'tumugi/parameter/error'
+require 'tumugi/error'
 require 'tumugi/parameter/parameter_proxy'
 
 module Tumugi
@@ -30,7 +30,7 @@ module Tumugi
       def validate_params(params)
         params.each do |name, param|
           if param.required? && instance_variable_get("@#{name}").nil?
-            raise Tumugi::Parameter::ParameterError.new("Parameter #{name} is required")
+            raise Tumugi::ParameterError.new("Parameter #{name} is required")
           end
         end
       end

--- a/lib/tumugi/parameter/error.rb
+++ b/lib/tumugi/parameter/error.rb
@@ -1,6 +1,0 @@
-module Tumugi
-  module Parameter
-    class ParameterError < StandardError
-    end
-  end
-end

--- a/lib/tumugi/parameter/parameter.rb
+++ b/lib/tumugi/parameter/parameter.rb
@@ -1,5 +1,5 @@
+require 'tumugi/error'
 require 'tumugi/parameter/converter'
-require 'tumugi/parameter/error'
 
 module Tumugi
   module Parameter
@@ -72,7 +72,7 @@ module Tumugi
 
       def validate
         if required? && default_value != nil
-          raise ParameterError.new("When you set required: true, you cannot set default value")
+          raise Tumugi::ParameterError.new("When you set required: true, you cannot set default value")
         end
       end
     end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -1,0 +1,49 @@
+require_relative './test_helper'
+require 'tumugi/error'
+
+class Tumugi::TumugiErrorTest < Test::Unit::TestCase
+  test 'TumugiError' do
+    err = Tumugi::TumugiError.new
+    assert_equal('Tumugi::TumugiError', err.message)
+    assert_nil(err.reason)
+
+    err = Tumugi::TumugiError.new('message')
+    assert_equal('message', err.message)
+    assert_nil(err.reason)
+
+    reason = RuntimeError.new('wrapped')
+    err = Tumugi::TumugiError.new('message', reason)
+    assert_equal('message', err.message)
+    assert_equal(reason, err.reason)
+  end
+
+  test 'ConfigError' do
+    err = Tumugi::ConfigError.new
+    assert_equal('Tumugi::ConfigError', err.message)
+    assert_nil(err.reason)
+
+    err = Tumugi::ConfigError.new('message')
+    assert_equal('message', err.message)
+    assert_nil(err.reason)
+
+    reason = RuntimeError.new('wrapped')
+    err = Tumugi::ConfigError.new('message', reason)
+    assert_equal('message', err.message)
+    assert_equal(reason, err.reason)
+  end
+
+  test 'ParameterError' do
+    err = Tumugi::ParameterError.new
+    assert_equal('Tumugi::ParameterError', err.message)
+    assert_nil(err.reason)
+
+    err = Tumugi::ParameterError.new('message')
+    assert_equal('message', err.message)
+    assert_nil(err.reason)
+
+    reason = RuntimeError.new('wrapped')
+    err = Tumugi::ParameterError.new('message', reason)
+    assert_equal('message', err.message)
+    assert_equal(reason, err.reason)
+  end
+end

--- a/test/parameter/parameter_proxy_test.rb
+++ b/test/parameter/parameter_proxy_test.rb
@@ -41,7 +41,7 @@ class Tumugi::Parameter::ParameterProxyTest < Test::Unit::TestCase
     end
 
     test 'raise ParameterError when both required and default is set' do
-      assert_raise(Tumugi::Parameter::ParameterError) do
+      assert_raise(Tumugi::ParameterError) do
         @proxy.param(:param1, required: true, default: 'test')
       end
     end

--- a/test/parameter/parameter_test.rb
+++ b/test/parameter/parameter_test.rb
@@ -26,7 +26,7 @@ class Tumugi::Parameter::ParameterTest < Test::Unit::TestCase
     end
 
     test 'raise ParameterError when both required and default is set' do
-      assert_raise(Tumugi::Parameter::ParameterError) do
+      assert_raise(Tumugi::ParameterError) do
         Tumugi::Parameter::Parameter.new(:name, required: true, default: 'test')
       end
     end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -183,7 +183,7 @@ class Tumugi::TaskTest < Test::Unit::TestCase
 
     sub_test_case 'raise ParameterError when required parameter is not set' do
       test 'not set' do
-        assert_raise(Tumugi::Parameter::ParameterError) do
+        assert_raise(Tumugi::ParameterError) do
           TestSubTask.new
         end
       end
@@ -191,7 +191,7 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       test 'set nil' do
         klass = Class.new(TestSubTask)
         klass.param_set(:param_string_in_subclass, nil)
-        assert_raise(Tumugi::Parameter::ParameterError) do
+        assert_raise(Tumugi::ParameterError) do
           klass.new
         end
       end


### PR DESCRIPTION
Fix #51
- All custom error class inherits Tumugi::TumugiError
- Wrap original error to Tumugi::TumugiError
- Logging backtrace if task failed
