### PR TITLE
Add Tumugi.configure method to modify config.

### DIFF
--- a/examples/tumugi_config.rb
+++ b/examples/tumugi_config.rb
@@ -1,4 +1,4 @@
-Tumugi.config do |c|
-  c.max_retry = 3
-  c.retry_interval = 1
+Tumugi.configure do |config|
+  config.max_retry = 3
+  config.retry_interval = 1
 end

--- a/examples/tumugi_config_with_section.rb
+++ b/examples/tumugi_config_with_section.rb
@@ -1,8 +1,8 @@
-Tumugi.config do |c|
-  c.max_retry = 3
-  c.retry_interval = 1
+Tumugi.configure do |config|
+  config.max_retry = 3
+  config.retry_interval = 1
 
-  c.section('example') do |s|
-    s.key = 'value'
+  config.section('example') do |section|
+    section.key = 'value'
   end
 end

--- a/lib/tumugi.rb
+++ b/lib/tumugi.rb
@@ -1,5 +1,6 @@
 require 'tumugi/application'
 require 'tumugi/config'
+require 'tumugi/error'
 require 'tumugi/logger'
 require 'tumugi/version'
 
@@ -13,10 +14,21 @@ module Tumugi
       @logger ||= Tumugi::Logger.new
     end
 
+    def configure(&block)
+      raise Tumugi::ConfigError.new 'Tumugi.configure must have block' unless block_given?
+      yield _config
+      nil
+    end
+
     def config
+      raise Tumugi::ConfigError.new 'Tumugi.config with block is deprecated. Use Tumugi.configure instead.' if block_given?
+      _config.clone.freeze
+    end
+
+    private
+
+    def _config
       @config ||= Tumugi::Config.new
-      yield @config if block_given?
-      @config
     end
   end
 end

--- a/test/command/run_test.rb
+++ b/test/command/run_test.rb
@@ -18,7 +18,7 @@ class Tumugi::Command::RunTest < Test::Unit::TestCase
   end
 
   teardown do
-    Tumugi.config do |config|
+    Tumugi.configure do |config|
       config.timeout = 0
     end
   end
@@ -42,7 +42,7 @@ class Tumugi::Command::RunTest < Test::Unit::TestCase
       def @task.run
         raise 'always failed'
       end
-      Tumugi.config do |config|
+      Tumugi.configure do |config|
         config.max_retry = 2
         config.retry_interval = 1
       end
@@ -53,7 +53,7 @@ class Tumugi::Command::RunTest < Test::Unit::TestCase
     end
 
     test 'failed when task got timeout' do
-      Tumugi.config do |config|
+      Tumugi.configure do |config|
         config.timeout = 1
       end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -40,8 +40,19 @@ class Tumugi::ConfigTest < Test::Unit::TestCase
     end
 
     test 'raise error when section is not registered before call' do
-      assert_raise do
+      assert_raise(Tumugi::ConfigError) do
         @config.section('not_registered_section')
+      end
+    end
+
+    test 'raise error when change section value' do
+      Tumugi::Config.register_section('name3', :key3)
+      assert_raise(Tumugi::ConfigError) do
+        config = @config.clone.freeze
+        config.section('name3') { |s| s.key3 = 'value3' }
+        section = config.section('name3')
+        assert_equal('value3', section.key3)
+        section.key3 = 'another value'
       end
     end
   end

--- a/test/parameter/parameter_test.rb
+++ b/test/parameter/parameter_test.rb
@@ -34,11 +34,15 @@ class Tumugi::Parameter::ParameterTest < Test::Unit::TestCase
 
   sub_test_case '#auto_bind?' do
     teardown do
-      Tumugi.config.param_auto_bind_enabled = true
+      Tumugi.configure do |config|
+        config.param_auto_bind_enabled = true
+      end
     end
 
     test 'should return false when global param_auto_bind_enabled is false' do
-      Tumugi.config.param_auto_bind_enabled = false
+      Tumugi.configure do |config|
+        config.param_auto_bind_enabled = false
+      end
       param = Tumugi::Parameter::Parameter.new(:name)
       assert_false(param.auto_bind?)
     end
@@ -50,7 +54,9 @@ class Tumugi::Parameter::ParameterTest < Test::Unit::TestCase
     end
 
     test 'should return true when auto_bind option is true' do
-      Tumugi.config.param_auto_bind_enabled = false
+      Tumugi.configure do |config|
+        config.param_auto_bind_enabled = false
+      end
       param = Tumugi::Parameter::Parameter.new(:name, auto_bind: true)
       assert_true(param.auto_bind?)
     end

--- a/test/tumugi_test.rb
+++ b/test/tumugi_test.rb
@@ -32,16 +32,28 @@ class TumugiTest < Test::Unit::TestCase
   end
 
   sub_test_case '#config' do
-    test 'returns Tumugi::Logger instance' do
+    test 'returns Tumugi::Config instance' do
       assert_equal(Tumugi::Config, Tumugi.config.class)
     end
 
-    test 'returns same instance when called multiple' do
-      assert_same(Tumugi.config, Tumugi.config)
+    test 'raise error when call #config with block' do
+      assert_raise(Tumugi::ConfigError) do
+        Tumugi.config do |c|
+          c.workers = 2
+          c.max_retry = 4
+          c.retry_interval = 600
+        end
+      end
+    end
+  end
+
+  sub_test_case '#configure' do
+    test 'returns nil' do
+      assert_nil(Tumugi.configure {})
     end
 
     test 'can change config values by block' do
-      Tumugi.config do |c|
+      Tumugi.configure do |c|
         c.workers = 2
         c.max_retry = 4
         c.retry_interval = 600


### PR DESCRIPTION
and change Tumugi.config and Tumugi.config.section('x') returns
frozen hash to prevent unintentional config change by task and plugins.

Fix #60 
