### PR TITLE
Call init first Tumugi::Logger instance access

### DIFF
--- a/lib/tumugi/logger.rb
+++ b/lib/tumugi/logger.rb
@@ -8,6 +8,10 @@ module Tumugi
     extend Forwardable
     def_delegators :@logger, :debug, :error, :fatal, :info, :warn, :level
 
+    def initialize
+      init
+    end
+
     def init(output=STDOUT)
       @logger = ::Logger.new(output)
       @logger.level = ::Logger::INFO


### PR DESCRIPTION
Follow up #36

Initialize `Tumugi::Logger.instance` when they first call. This is prevent nil access error, especially plugin test.
