### PR TITLE
Fix logger not defiend in Tumugi::Config

### DIFF
--- a/lib/tumugi/config.rb
+++ b/lib/tumugi/config.rb
@@ -52,7 +52,7 @@ module Tumugi
         begin
           @section_procs[name].call(@section_instances[name])
         rescue NoMethodError => e
-          logger.error "#{e.message}. Available attributes are #{@section_instances[name].members}"
+          Config.logger.error "#{e.message}. Available attributes are #{@section_instances[name].members}"
           raise e
         end if @section_procs[name]
       end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -54,5 +54,14 @@ class Tumugi::ConfigTest < Test::Unit::TestCase
         section.key3 = 'another value'
       end
     end
+
+    test 'raise error when set wrong key' do
+      Tumugi::Config.register_section('name1', :key1)
+
+      assert_raise(NoMethodError) do
+        @config.section('name1') { |s| s.key2 = 'value1' }
+        @config.section('name1').key1
+      end
+    end
   end
 end


### PR DESCRIPTION
When set wrong key for config section, we got following error. This PR fix this.

```
Error: test: raise error when set wrong key(Tumugi::ConfigTest::#section): NoMethodError: undefined method `logger' for #<Tumugi::Config:0x007fedcbd827a8>
/Users/k-honda/src/github.com/tumugi/tumugi/lib/tumugi/config.rb:55:in `rescue in section'
/Users/k-honda/src/github.com/tumugi/tumugi/lib/tumugi/config.rb:52:in `section'
test/config_test.rb:61:in `block (2 levels) in <class:ConfigTest>'
```
