### PR TITLE
Introduce new DSL syntax: set

### DIFF
--- a/examples/task_parameter.rb
+++ b/examples/task_parameter.rb
@@ -8,10 +8,9 @@ task :task1 do
 end
 
 task :task2 do
-  # If you want do disable auto binding feature, set `auto_bind: false`
-  param :key1, auto_bind: false #=> nil
+  param :key1
   param :key2
-  param_set :key2, 'value2' #=> 'value'
+  set :key2, 'value2' #=> 'value'
 
   requires :task3
   run do

--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -1,4 +1,5 @@
 require 'tumugi/error'
+require 'tumugi/logger'
 require 'tumugi/parameter/parameter_proxy'
 
 module Tumugi
@@ -70,8 +71,13 @@ module Tumugi
           end
         end
 
+        def set(name, value)
+          parameter_proxy(proxy_id).set(name, value)
+        end
+
         def param_set(name, value)
-          parameter_proxy(proxy_id).param_set(name, value)
+          Tumugi::Logger.instance.warn("'param_set' is deprecated and will be removed in a future release. Use 'set' instead.")
+          set(name, value)
         end
 
         def param_auto_bind_enabled(v)

--- a/lib/tumugi/parameter/parameter_proxy.rb
+++ b/lib/tumugi/parameter/parameter_proxy.rb
@@ -22,7 +22,7 @@ module Tumugi
         @params[name] = Tumugi::Parameter::Parameter.new(name, opts)
       end
 
-      def param_set(name, value)
+      def set(name, value)
         @param_defaults[name] = value
       end
 

--- a/lib/tumugi/task_definition.rb
+++ b/lib/tumugi/task_definition.rb
@@ -1,5 +1,6 @@
-require 'tumugi/task'
+require 'tumugi/logger'
 require 'tumugi/plugin'
+require 'tumugi/task'
 require 'tumugi/mixin/listable'
 require 'tumugi/mixin/task_helper'
 
@@ -36,8 +37,13 @@ module Tumugi
       @params[name] = opts
     end
 
-    def param_set(name, value)
+    def set(name, value)
       @param_defaults[name] = value
+    end
+
+    def param_set(name, value)
+      Tumugi::Logger.instance.warn("'param_set' is deprecated and will be removed in a future release. Use 'set' instead.")
+      set(name, value)
     end
 
     def param_auto_bind_enabled(v)
@@ -127,7 +133,7 @@ module Tumugi
         task_class.param(name, opts)
       end
       @param_defaults.each do |name, value|
-        task_class.param_set(name, value)
+        task_class.set(name, value)
       end
       unless @param_auto_bind_enabled.nil?
         task_class.param_auto_bind_enabled(@param_auto_bind_enabled)

--- a/test/parameter/parameter_proxy_test.rb
+++ b/test/parameter/parameter_proxy_test.rb
@@ -47,9 +47,9 @@ class Tumugi::Parameter::ParameterProxyTest < Test::Unit::TestCase
     end
   end
 
-  sub_test_case '#param_set' do
+  sub_test_case '#set' do
     test 'should add param_defaults' do
-      @proxy.param_set(:param1, 'value1')
+      @proxy.set(:param1, 'value1')
       assert_true(@proxy.param_defaults.has_key?(:param1))
       assert_equal('value1', @proxy.param_defaults[:param1])
     end

--- a/test/task_definition_test.rb
+++ b/test/task_definition_test.rb
@@ -140,9 +140,9 @@ class Tumugi::TaskDefinitionTest < Test::Unit::TestCase
         assert_equal('value1', task.key1)
       end
 
-      test 'param_set should assign default value' do
+      test 'set should assign default value' do
         @task_def.param(:key1)
-        @task_def.param_set(:key1, 'value1')
+        @task_def.set(:key1, 'value1')
         @task_def.run {|t| t.key1}
         task = @task_def.instance
         assert_true(task.respond_to?(:key1))

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -39,15 +39,15 @@ class Tumugi::TaskTest < Test::Unit::TestCase
   end
 
   class TestSubSubTask < TestSubTask
-    param_set :param_string_in_subclass, 'TestSubSubTask'
+    set :param_string_in_subclass, 'TestSubSubTask'
   end
 
   class TestSubSub2Task < TestSubTask
-    param_set :param_string_in_subclass, 'TestSubSub2Task'
+    set :param_string_in_subclass, 'TestSubSub2Task'
   end
 
   class TestSubSub3Task < TestSubTask
-    param_set :param_string_in_subclass, ->{ @value += 1 }
+    set :param_string_in_subclass, ->{ @value += 1 }
 
     def initialize(value)
       super()
@@ -194,14 +194,14 @@ class Tumugi::TaskTest < Test::Unit::TestCase
 
       test 'set nil' do
         klass = Class.new(TestSubTask)
-        klass.param_set(:param_string_in_subclass, nil)
+        klass.set(:param_string_in_subclass, nil)
         assert_raise(Tumugi::ParameterError) do
           klass.new
         end
       end
     end
 
-    test 'subclass can access and set parameter value by param_set' do
+    test 'subclass can access and set parameter value by set' do
       task = TestSubSubTask.new
       assert_true(task.respond_to? "param_string_in_subclass".to_sym)
       assert_true(task.respond_to? "param_string_in_subclass=".to_sym)
@@ -214,7 +214,7 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       assert_equal('TestSubSub2Task', task.param_string_in_subclass)
     end
 
-    test 'param_set can accept Proc and evaluate it later and instance scope and cache results' do
+    test 'set can accept Proc and evaluate it later and instance scope and cache results' do
       task = TestSubSub3Task.new(1)
       assert_equal(2, task.param_string_in_subclass)
       assert_equal(2, task.param_string_in_subclass)


### PR DESCRIPTION
Instead of `param_set`. Imprement part of #81 

Currently set parameter is done by `param_set` method in tumugi DSL, but it's little a bit long to type.
So I introduce short alias `set`. Following codes do same behavior.

``` rb
task :main, type: plugin do
  param_set :key, 'value
end
```

``` rb
task :main, type: plugin do
  set :key, 'value
end
```

You can still use `param_set`, but will be removed in a future release, so I recommend to change your `param_set` to `set`.
