### PR TITLE
Add short cut method to set parmeter in DSL

### DIFF
--- a/examples/task_inheritance.rb
+++ b/examples/task_inheritance.rb
@@ -1,12 +1,15 @@
 class FileTask < Tumugi::Task
   Tumugi::Plugin.register_task(:file, self)
 
+  param :param1, type: :string
+
   def output
     target(:local_file, "tmp/#{id}.txt")
   end
 
   def run
     log "#{id}#run"
+    log param1
     output.open('w') do |f|
       f.puts('done')
     end
@@ -16,16 +19,20 @@ end
 # Task type can specified by task plugin ID
 task :task1, type: :file do
   requires [:task2, :task3]
+  param1 'param1 of task1'
 end
 
 task :task2, type: :file do
   requires [:task4]
+  param1 'param1 of task2'
 end
 
 # You can also specify type by Class object
 task :task3, type: FileTask do
   requires [:task4]
+  param1 'param1 of task3'
 end
 
 task :task4, type: FileTask do
+  param1 'param1 of task4'
 end

--- a/examples/task_parameter.rb
+++ b/examples/task_parameter.rb
@@ -10,7 +10,7 @@ end
 task :task2 do
   param :key1
   param :key2
-  set :key2, 'value2' #=> 'value'
+  key2 'value2' #=> 'value'
 
   requires :task3
   run do

--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -90,7 +90,7 @@ module Tumugi
         end
 
         def dump
-          parameter_proxy_map[proxy_id].dump
+          parameter_proxy(proxy_id).dump
         end
 
         def proxy_id

--- a/lib/tumugi/mixin/parameterizable.rb
+++ b/lib/tumugi/mixin/parameterizable.rb
@@ -57,6 +57,9 @@ module Tumugi
         end
 
         def param(name, opts={})
+          if instance_methods.include?(name)
+            raise Tumugi::ParameterError.new("Parameter '#{name}' cannot use, because it is already defined or override instance method.")
+          end
           parameter_proxy(proxy_id).param(name, opts)
           attr_writer name
           define_method(name) do

--- a/test/task_definition_test.rb
+++ b/test/task_definition_test.rb
@@ -9,13 +9,13 @@ class Tumugi::TaskDefinitionTest < Test::Unit::TestCase
   sub_test_case 'initialize' do
     test 'id' do
       assert_equal(:test, @task_def.id)
+      assert_equal('b', @task_def.opts[:a])
     end
 
     sub_test_case 'opts' do
       test 'type is class' do
         assert_equal(2, @task_def.opts.size)
-        assert_equal(Tumugi::Task, @task_def.opts[:type])
-        assert_equal('b', @task_def.opts[:a])
+        assert_equal(Tumugi::Task, @task_def.parent_task_class)
       end
 
       test 'type is plugin ID' do
@@ -23,7 +23,7 @@ class Tumugi::TaskDefinitionTest < Test::Unit::TestCase
           Tumugi::Plugin.register_task(:test, self)
         end
         @task_def = Tumugi::TaskDefinition.new(:test, type: :test)
-        assert_equal(TestTask, @task_def.opts[:type])
+        assert_equal(TestTask, @task_def.parent_task_class)
       end
     end
   end
@@ -140,9 +140,18 @@ class Tumugi::TaskDefinitionTest < Test::Unit::TestCase
         assert_equal('value1', task.key1)
       end
 
-      test 'set should assign default value' do
+      test 'set should assign default value by set' do
         @task_def.param(:key1)
         @task_def.set(:key1, 'value1')
+        @task_def.run {|t| t.key1}
+        task = @task_def.instance
+        assert_true(task.respond_to?(:key1))
+        assert_equal('value1', task.key1)
+      end
+
+      test 'set should assign default value by named method' do
+        @task_def.param(:key1)
+        @task_def.key1('value1')
         @task_def.run {|t| t.key1}
         task = @task_def.instance
         assert_true(task.respond_to?(:key1))

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -219,6 +219,23 @@ class Tumugi::TaskTest < Test::Unit::TestCase
       assert_equal(2, task.param_string_in_subclass)
       assert_equal(2, task.param_string_in_subclass)
     end
+
+    sub_test_case 'raise ParameterError when parameter name cannot use' do
+      test 'override instance method' do
+        klass = Class.new(TestTask)
+        assert_raise(Tumugi::ParameterError) do
+          klass.param(:output, type: :string)
+        end
+      end
+
+      test 'defined twice' do
+        klass = Class.new(TestTask)
+        assert_raise(Tumugi::ParameterError) do
+          klass.param(:param1, type: :string)
+          klass.param(:param1, type: :string)
+        end
+      end
+    end
   end
 
   sub_test_case '#requires_failed' do


### PR DESCRIPTION
Part of #81 

Currently we need to call `set` method to set parameter value in DSL like

``` rb
task task1, type: :some_task do
  set :key1, 'value'
end
```

But it's a little bit redundant. So I introduce short cut method to do same thing like

``` rb
task task1, type: :some_task do
  key1 'value'
end
```
