### PR TITLE
Fix result reporting failed if parameter type is not :string

### DIFF
--- a/examples/task_parameter.rb
+++ b/examples/task_parameter.rb
@@ -1,5 +1,5 @@
 task :task1 do
-  param :key1, auto_bind: true, required: true #=> 'value1', get value from CLI parameter
+  param :key1, auto_bind: true, required: true #=> get value from CLI parameter
 
   requires :task2
   run do
@@ -9,8 +9,8 @@ end
 
 task :task2 do
   param :key1
-  param :key2
-  key2 'value2' #=> 'value'
+  param :key2, type: :time
+  key2 Time.parse('2016-06-27')
 
   requires :task3
   run do

--- a/lib/tumugi/command/run.rb
+++ b/lib/tumugi/command/run.rb
@@ -110,7 +110,7 @@ module Tumugi
               r.id
             end
             params = proxy.params.map do |name, _|
-              "#{name}=#{truncate(task.send(name.to_sym), 15)}"
+              "#{name}=#{truncate(task.send(name.to_sym).to_s, 25)}"
             end
             t << :separator if index != 0
             t << [ task.id, requires.join("\n"), params.join("\n"), task.state ]


### PR DESCRIPTION
Fix bug introduced by #83 
