### PR TITLE
Remove development dependency: github_changelog_generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,10 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
-require "github_changelog_generator/task"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
 end
 
 task :default => :test

--- a/tumugi.gemspec
+++ b/tumugi.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit', '~> 3.1'
   spec.add_development_dependency 'test-unit-rr'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'github_changelog_generator'
 end


### PR DESCRIPTION
Because this is only needed for updating CHANGELOG.md, so not needed for development.
This also fix test failed with ruby < 2.2.2, because of [Rack 2.0.1 release to rubygem.org](https://rubygems.org/gems/rack/versions/2.0.1)
