### PR TITLE
Remove File.exists?

### DIFF
--- a/lib/tumugi/application.rb
+++ b/lib/tumugi/application.rb
@@ -81,7 +81,7 @@ module Tumugi
 
     def load_config(options)
       config_file = options[:config]
-      if config_file && File.exists?(config_file) && File.extname(config_file) == '.rb'
+      if config_file && File.exist?(config_file) && File.extname(config_file) == '.rb'
         logger.info "Load config from #{config_file}"
         load(config_file)
       end

--- a/test/command/show_test.rb
+++ b/test/command/show_test.rb
@@ -27,7 +27,7 @@ class Tumugi::Command::ShowTest < Test::Unit::TestCase
     )
     test 'output specified formated file' do |output|
       @cmd.execute(@dag, out: output)
-      assert_true(File.exists?(output))
+      assert_true(File.exist?(output))
     end
 
     data(


### PR DESCRIPTION
`File.exists?` is deprecated method, so I replace it to `File.exist?`

http://ruby-doc.org/core-2.2.0/File.html
