### PR TITLE
Test with jruby-9.1.5.0 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.3.1
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-9.1.2.0
+  - jruby-9.1.5.0
   - jruby-head
 before_install:
   - gem install bundler


### PR DESCRIPTION
JRuby latest stable version is 9.1.5.0, so I update it on travis.

ref: http://jruby.org/2016/09/06/jruby-9-1-5-0
